### PR TITLE
Equals method bug fix

### DIFF
--- a/Maxxor.PCL/Collections/ImmediatePriorityQueue.cs
+++ b/Maxxor.PCL/Collections/ImmediatePriorityQueue.cs
@@ -96,7 +96,7 @@ namespace Maxxor.PCL.Collections
 
         public bool TryAdd(T item)
         {
-            if (item == null || _allItems.ContainsKey(item) && _allItems[item] != null)
+            if (item == null || _allItems.ContainsKey(item))
                 return false;
 
             var newItemNode = new LinkedListNode(item);
@@ -118,7 +118,7 @@ namespace Maxxor.PCL.Collections
 
         public bool MoveToFront(T item)
         {
-            if (item == null || !_allItems.ContainsKey(item) || _allItems[item] == null)
+            if (item == null || !_allItems.ContainsKey(item))
                 return false;
 
             if (_head.Value.Equals(item)) return true;

--- a/Maxxor.PCL/ValueObject/Base/MxValueObject.cs
+++ b/Maxxor.PCL/ValueObject/Base/MxValueObject.cs
@@ -58,7 +58,7 @@ namespace Maxxor.PCL.ValueObject.Base
             if (t != otherType)
                 return false;
 
-            var fields = t.GetRuntimeFields();
+            var fields = GetFields();
 
             foreach (var field in fields)
             {


### PR DESCRIPTION
Changed MxValueObject equals method to check base classes and removed redundant check on ImmediatePriorityQueue